### PR TITLE
Add d to res.locals so can be accessed elsewhere

### DIFF
--- a/lib/domain.js
+++ b/lib/domain.js
@@ -82,6 +82,8 @@ module.exports = function createMiddleware(options) {
         }
       }
     });
+    
+    res.locals.domain = d;
 
     d.run(next);
   };


### PR DESCRIPTION
Our app is using and express error-handler middleware `function(err,req,res,next)` to shoot of emails, trigger New Relic error event, `res.json(500,..)`, etc. However, as a result, errors (even thrown) are handled there, and not caught by `d.on('error')` - and we don't get the worker restart goodies this module provides. The way I'm getting around it presently is adding `res.locals.domain=d;` (this commit), and in our error-handler calling `res.locals.domain.emit('error', err);`. There a better way about this?
